### PR TITLE
Specified locale for language, encoding and formatting

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -68,6 +68,14 @@
       keyboard_model: pc105
       keyboard_layout: gb
 
+    # Configure locale
+    - role: tersmitten.locales
+      locales_present:
+        - en_GB.UTF-8
+        - en_US.UTF-8
+      locales_default:
+        lang: en_GB.UTF-8
+
     # Enable compressed RAM swap
     - gantsign.zram-config
 

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -6,6 +6,7 @@
 - src: franklinkim.environment
 - src: cmprescott.chrome
 - src: geerlingguy.nodejs
+- src: tersmitten.locales
 - src: gantsign.apt
 - src: gantsign.atom
 - src: gantsign.audio


### PR DESCRIPTION
Default is now en_GB.UTF-8.

Enhancement: resolves #11