### PR TITLE
Renamed download dir variables

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -3,8 +3,9 @@
   become: yes
 
   vars:
-    local_ansible_data_path: /usr/local/src/ansible/data
-    cached_ansible_data_path: /tmp/vagrant-cache/ansible/data
+    x_ansible_download_dir: /usr/local/src/ansible/data
+    local_ansible_data_path: "{{ x_ansible_download_dir }}"
+    cached_ansible_download_dir: /tmp/vagrant-cache/ansible/downloads
 
   pre_tasks:
     - name: update apt cache
@@ -13,10 +14,10 @@
     # Can't cache /usr/local/src/ansible directly.
     - name: restore ansible download cache
       shell: >
-        [ -d "{{ cached_ansible_data_path }}" ] || exit 0 ;
-        [ "$(ls --almost-all {{ cached_ansible_data_path }})" ] || exit 0 ;
-        mkdir --parents {{ local_ansible_data_path }}
-        && cp --recursive --no-clobber {{ cached_ansible_data_path }}/* {{ local_ansible_data_path }}
+        [ -d "{{ cached_ansible_download_dir }}" ] || exit 0 ;
+        [ "$(ls --almost-all {{ cached_ansible_download_dir }})" ] || exit 0 ;
+        mkdir --parents {{ x_ansible_download_dir }}
+        && cp --recursive --no-clobber {{ cached_ansible_download_dir }}/* {{ x_ansible_download_dir }}
         || exit 1
 
   post_tasks:
@@ -24,10 +25,10 @@
     # Can't cache /usr/local/src/ansible directly.
     - name: cache ansible downloads
       shell: >
-        [ -d "{{ local_ansible_data_path }}" ] || exit 0 ;
-        [ "$(ls --almost-all {{ local_ansible_data_path }})" ] || exit 0 ;
-        mkdir --parents {{ cached_ansible_data_path }}
-        && cp --recursive --no-clobber {{ local_ansible_data_path }}/* {{ cached_ansible_data_path }}
+        [ -d "{{ x_ansible_download_dir }}" ] || exit 0 ;
+        [ "$(ls --almost-all {{ x_ansible_download_dir }})" ] || exit 0 ;
+        mkdir --parents {{ cached_ansible_download_dir }}
+        && cp --recursive --no-clobber {{ x_ansible_download_dir }}/* {{ cached_ansible_download_dir }}
         || exit 1
 
   roles:
@@ -174,8 +175,8 @@
       tags:
         - java
         - gui
-      intellij_default_jdk_home: "{{ ansible_local.java.general.java_home }}"
-      intellij_default_maven_home: "{{ ansible_local.maven.general.maven_home }}"
+      intellij_default_jdk_home: "{{ ansible_local.java.general.home }}"
+      intellij_default_maven_home: "{{ ansible_local.maven.general.home }}"
       users:
         - username: vagrant
           intellij_disabled_plugins:
@@ -209,7 +210,7 @@
             - 'gitkraken;/usr/share/applications/gitkraken.desktop'
             - 'atom;/usr/share/applications/atom.desktop'
             - 'code;/usr/share/applications/code.desktop'
-            - 'idea;{{ ansible_local.intellij.general.intellij_desktop_file }}'
+            - 'idea;{{ ansible_local.intellij.general.desktop_file }}'
 
     # Configure general environment variables
     - role: franklinkim.environment
@@ -223,8 +224,8 @@
       tags:
         - java
       environment_config:
-        JAVA_HOME: "{{ ansible_local.java.general.java_home }}"
-        IDEA_JDK: "{{ ansible_local.java.general.java_home }}"
+        JAVA_HOME: "{{ ansible_local.java.general.home }}"
+        IDEA_JDK: "{{ ansible_local.java.general.home }}"
 
     # Configure Maven environment variable
     - role: franklinkim.environment
@@ -232,7 +233,7 @@
         - java
         - maven
       environment_config:
-        M2_HOME: "{{ ansible_local.maven.general.maven_home }}"
+        M2_HOME: "{{ ansible_local.maven.general.home }}"
 
     # Install oh-my-zsh shell enhancements
     - role: gantsign.oh-my-zsh


### PR DESCRIPTION
The variable `local_ansible_data_path` was misleading as from the Ansible perspective it's on the remote machine. Renamed `cached_ansible_data_path` in line with new name for `local_ansible_data_path`.