### PR TITLE
Eliminated local_ansible_data_path var

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -4,7 +4,6 @@
 
   vars:
     x_ansible_download_dir: /usr/local/src/ansible/data
-    local_ansible_data_path: "{{ x_ansible_download_dir }}"
     cached_ansible_download_dir: /tmp/vagrant-cache/ansible/downloads
 
   pre_tasks:

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -24,7 +24,7 @@
 - src: gantsign.dockbarx-launcher
   version: '2.1.0'
 - src: gantsign.gitkraken
-  version: '1.1.0'
+  version: '2.0.0'
 - src: gantsign.intellij
 - src: gantsign.java
   version: '3.0.0'


### PR DESCRIPTION
It's now completely replaced by `x_ansible_download_dir`.