### PR TITLE
Switched to pin-to-launcher role

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -208,19 +208,18 @@
         - gui
 
     # Add items to DockbarX launcher
-    - role: gantsign.dockbarx-launcher
+    - role: gantsign.pin-to-launcher
       tags:
         - gui
-      users:
-        - username: vagrant
-          docbarx_launcher_items:
-            - 'exo-terminal-emulator;/usr/share/applications/exo-terminal-emulator.desktop'
-            - 'thunar;/usr/share/applications/Thunar-folder-handler.desktop'
-            - 'google-chrome;/usr/share/applications/google-chrome.desktop'
-            - 'gitkraken;/usr/share/applications/gitkraken.desktop'
-            - 'atom;/usr/share/applications/atom.desktop'
-            - 'code;/usr/share/applications/code.desktop'
-            - 'idea;{{ ansible_local.intellij.general.desktop_file }}'
+      pin_to_launcher: dockbarx
+      pin_to_launcher_favorites:
+        - application: exo-terminal-emulator.desktop
+        - application: Thunar-folder-handler.desktop
+        - application: google-chrome.desktop
+        - application: gitkraken.desktop
+        - application: atom.desktop
+        - application: code.desktop
+        - application: "{{ ansible_local.intellij.general.desktop_filename }}"
 
     # Configure general environment variables
     - role: franklinkim.environment

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -21,8 +21,6 @@
   version: '1.1.1'
 - src: https://github.com/gantsign/ansible-role-command-line-tools/archive/1.1.1.tar.gz
   name: gantsign.command-line-tools
-- src: gantsign.dockbarx-launcher
-  version: '2.1.1'
 - src: gantsign.gitkraken
   version: '2.0.1'
 - src: gantsign.intellij
@@ -42,6 +40,8 @@
   version: '1.0.0'
 - src: gantsign.oh-my-zsh
   version: '1.0.1'
+- src: gantsign.pin-to-launcher
+  version: '1.0.0'
 - src: https://github.com/gantsign/ansible-role-unison/archive/1.1.1.tar.gz
   name: gantsign.unison
 - src: gantsign.visual-studio-code


### PR DESCRIPTION
The previous gantsign.dockbarx-launcher didn't support the Unity desktop.