### PR TITLE
Fixed corrupted boot console prompt

### DIFF
--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -39,7 +39,7 @@
 - src: gantsign.molecule
   version: '1.0.0'
 - src: gantsign.oh-my-zsh
-  version: '1.0.1'
+  version: '1.1.0'
 - src: gantsign.pin-to-launcher
   version: '1.0.0'
 - src: https://github.com/gantsign/ansible-role-unison/archive/1.1.1.tar.gz


### PR DESCRIPTION
The oh-my-zsh prompt uses symbols to show whether the previous command completed successfully. If the console is running in ISO-8859-1 (or any other non-UTF-8 charmap the symbol appears as a series of garbled characters.

This fix changes the console to use UTF-8.