### PR TITLE
Fixed provisioning when IntelliJ not installed

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -219,7 +219,7 @@
         - application: gitkraken.desktop
         - application: atom.desktop
         - application: code.desktop
-        - application: "{{ ansible_local.intellij.general.desktop_filename }}"
+        - application: "{{ ansible_local.intellij.general.desktop_filename if (ansible_local is defined and ansible_local.intellij is defined) else omit }}"
 
     # Configure general environment variables
     - role: franklinkim.environment

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -41,7 +41,7 @@
 - src: gantsign.oh-my-zsh
   version: '1.1.0'
 - src: gantsign.pin-to-launcher
-  version: '1.0.0'
+  version: '1.1.0'
 - src: https://github.com/gantsign/ansible-role-unison/archive/1.1.1.tar.gz
   name: gantsign.unison
 - src: gantsign.visual-studio-code


### PR DESCRIPTION
The `pin-to-launcher` role was failing because either `ansible_local` or `ansible_local.intellij` was undefined.

Fix: resolves #37