### PR TITLE
Removed unnecessary space at end of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,5 +276,4 @@ The provisioning is done using Ansible (https://www.ansible.com/).
 
 If you want to customize the provisioning the place to start is the
 `provisioning/playbook.yml` file.
-
 [![Analytics](https://ga-beacon.appspot.com/UA-83612642-2/chromeskel_a/readme?pixel)](https://github.com/igrigorik/ga-beacon)


### PR DESCRIPTION
The ga-beacon was put in it's own paragraph.