### PR TITLE
Set the default web browser

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -165,6 +165,15 @@
         - gui
         - chrome
 
+    # Set the default web browser
+    # This is only a partial solution as Google Chrome will still ask if you
+    # want to make it the default browser when it first runs.
+    - role: gantsign.default-web-browser
+      tags:
+        - gui
+        - chrome
+      default_web_browser: google-chrome
+
     # Install GitKraken
     - role: gantsign.gitkraken
       tags:

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -21,6 +21,8 @@
   version: '1.1.1'
 - src: https://github.com/gantsign/ansible-role-command-line-tools/archive/1.1.1.tar.gz
   name: gantsign.command-line-tools
+- src: gantsign.default-web-browser
+  version: '1.0.0'
 - src: gantsign.gitkraken
   version: '2.1.0'
 - src: gantsign.intellij


### PR DESCRIPTION
While Google Chrome was the only browser installed, the user was still asked to choose a browser under Xfce4.