### PR TITLE
Configure IntelliJ to use GantSign code style

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -251,6 +251,10 @@
             - Subversion
             - AntSupport
             - DevKit
+          intellij_codestyles:
+            - name: GantSign
+              url: 'https://raw.githubusercontent.com/gantsign/code-style-intellij/1.0.0/GantSign.xml'
+          intellij_active_codestyle: GantSign
 
     # Add Maven extension to popup a GUI notification when builds finish
     - role: gantsign.maven-notifier


### PR DESCRIPTION
Configure IntelliJ IDEA to use GantSign code style for Java and XML.