### PR TITLE
Switched from vagrant-cachier to vagrant-persistent-storage

### DIFF
--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -98,28 +98,6 @@ see the [configuration]({{ base_path }}/docs/configuration) documentation.
 For more configuration options, including configuring regional preferences, view
 the [configuration]({{ base_path }}/docs/configuration) documentation.
 
-## Vagrant Cachier Plugin
-
-Website: [https://github.com/fgrehm/vagrant-cachier](https://github.com/fgrehm/vagrant-cachier)
-
-Installing the development environment requires a lot of installation packages
-to be downloaded; even on a fast internet connection this can take a while to
-complete. As it's standard practice to rebuild the development environment
-rather than manually installing software updates, it's better to cache these
-downloads on the host machine to speed up rebuilds.
-
-The Vagrant Cachier Plugin will configure various package managers on the client
-virtual machine; this configuration will cache most standard installation
-packages in a shared folder on the host machine (`~/.vagrant.d/cache`).
-
-If you have sufficient free disk space to store the cached installation
-packages, we recommend you install the Vagrant Cachier Plugin by running the
-following command:
-
-```bash
-vagrant plugin install vagrant-cachier
-```
-
 ## Run Vagrant
 
 All that's left is to run Vagrant to provision the virtual machine.

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -4,36 +4,15 @@
 
   vars:
     x_ansible_download_dir: /usr/local/src/ansible/data
-    cached_ansible_download_dir: /tmp/vagrant-cache/ansible/downloads
 
   pre_tasks:
     - name: update apt cache
       apt: update_cache=yes cache_valid_time=86400
-    # Workaround for https://github.com/ansible/ansible/issues/9526
-    # Can't cache /usr/local/src/ansible directly.
-    - name: restore ansible download cache
-      shell: >
-        [ -d "{{ cached_ansible_download_dir }}" ] || exit 0 ;
-        [ "$(ls --almost-all {{ cached_ansible_download_dir }})" ] || exit 0 ;
-        mkdir --parents {{ x_ansible_download_dir }}
-        && cp --recursive --no-clobber {{ cached_ansible_download_dir }}/* {{ x_ansible_download_dir }}
-        || exit 1
-
-  post_tasks:
-    # Workaround for https://github.com/ansible/ansible/issues/9526
-    # Can't cache /usr/local/src/ansible directly.
-    - name: cache ansible downloads
-      shell: >
-        [ -d "{{ x_ansible_download_dir }}" ] || exit 0 ;
-        [ "$(ls --almost-all {{ x_ansible_download_dir }})" ] || exit 0 ;
-        mkdir --parents {{ cached_ansible_download_dir }}
-        && cp --recursive --no-clobber {{ x_ansible_download_dir }}/* {{ cached_ansible_download_dir }}
-        || exit 1
 
   roles:
     # Preserve the apt cache
     - role: gantsign.apt
-      apt_preserve_cache: "{{ has_vagrant_cachier }}"
+      apt_preserve_cache: yes
 
     # Set system timezone
     - role: franklinkim.timezone


### PR DESCRIPTION
vagrant-cachier is no longer maintained and suffers from bugs on Ubuntu 16.04:
e.g. https://github.com/fgrehm/vagrant-cachier/issues/176