### PR TITLE
Fixed .editorconfig selector

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ indent_size = 4
 trim_trailing_whitespace = true
 
 # Files with a smaller indent
-[*.yml,Vagrantfile,Customfile.example,Customfile,.vagrantuser.example,.vagrantuser]
+[{*.yml,Vagrantfile,Customfile.example,Customfile,.vagrantuser.example,.vagrantuser}]
 indent_size = 2
 
 # Shell scripts can be fussy about line endings

--- a/docs/.editorconfig
+++ b/docs/.editorconfig
@@ -1,7 +1,10 @@
 # EditorConfig: http://EditorConfig.org
 
 # Files with a smaller indent
-[*.{scss,xml,html,md},Gemfile]
+[Gemfile]
+indent_size = 2
+
+[*.{scss,xml,html,md}]
 indent_size = 2
 
 # Specify encoding of Markdown files (as per _config.yml)


### PR DESCRIPTION
Lists of file patterns need to be surrounded by braces.