### PR TITLE
Fixed case of heading in features.md

### DIFF
--- a/docs/_docs/features.md
+++ b/docs/_docs/features.md
@@ -366,7 +366,7 @@ installation.
 
 ![IntelliJ IDEA IDE]({{ base_path }}/images/intellij.png)
 
-## For Ansible Developers
+## For Ansible developers
 
 ### Molecule
 


### PR DESCRIPTION
Headings in this document use uppercase for the first word and proper nouns only.