### PR TITLE
Fixed IntelliJ Ultimate regression

### DIFF
--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -35,7 +35,7 @@
   version: '1.0.0'
 - src: gantsign.intellij
 - src: gantsign.intellij-plugins
-  version: '1.0.1'
+  version: '1.0.2'
 - src: gantsign.java
   version: '3.4.0'
 - src: gantsign.keyboard


### PR DESCRIPTION
IntelliJ Ultimate Edition install has been failing since plugins were added as part of the install.