### PR TITLE
Fixed default audio settings for macOS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,6 +37,17 @@ Vagrant.configure(2) do |config|
   # `vagrant box outdated`. This is not recommended.
   # config.vm.box_check_update = false
 
+  # Specifying an unsupported audio setting will cause VirtualBox provisioning
+  # to fail.
+  default_vb_audio = nil
+  default_vb_audiocontroler = 'ac97'
+  if Vagrant::Util::Platform.windows?
+    default_vb_audio  = 'dsound'
+  elsif Vagrant::Util::Platform.mac?
+    default_vb_audio  = 'coreaudio'
+    default_vb_audiocontroler = 'hda'
+  end
+
   # Customizable configuration
   # See https://github.com/maoueh/nugrant
   config.user.defaults = {
@@ -95,8 +106,8 @@ Vagrant.configure(2) do |config|
       'memory' => '4096',
       'clipboard' => 'bidirectional',
       'draganddrop' => 'bidirectional',
-      'audio' => 'dsound',
-      'audiocontroller' => 'ac97'
+      'audio' => default_vb_audio,
+      'audiocontroller' => default_vb_audiocontroler
     },
 
     'java_license_declaration' => '',
@@ -179,8 +190,10 @@ Vagrant.configure(2) do |config|
     vb.customize ['modifyvm', :id, '--clipboard', config.user.virtualbox.clipboard]
     vb.customize ['modifyvm', :id, '--draganddrop', config.user.virtualbox.draganddrop]
 
-    # Enable sound
-    vb.customize ['modifyvm', :id, '--audio', config.user.virtualbox.audio, '--audiocontroller', config.user.virtualbox.audiocontroller]
+    unless config.user.virtualbox.audio.nil?
+      # Enable sound
+      vb.customize ['modifyvm', :id, '--audio', config.user.virtualbox.audio, '--audiocontroller', config.user.virtualbox.audiocontroller]
+    end
   end
 
   # Customfile

--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -5,7 +5,7 @@ description: >
   Instructions for how to configure your development environment.
 numbered_headings: yes
 date: 2016-09-02T14:47:02+01:00
-modified: 2016-09-02T14:47:02+01:00
+modified: 2016-11-23T12:09:35+00:00
 ---
 
 {% include base_path %}
@@ -261,17 +261,17 @@ virtualbox: # All VirtualBox configuration has to be under the same `virtualbox`
   cpus: 2
 ```
 
-#### Audio controller
+#### Audio
 
-If you're not running on Microsoft Windows you'll probably need to change the
-audio controller settings.
+If you're not running on Microsoft Windows or macOS you'll need to change the
+audio settings to enable audio support.
 
 You can find more information about VirtualBox audio options at:
 [https://www.virtualbox.org/manual/ch08.html#vboxmanage-modifyvm](https://www.virtualbox.org/manual/ch08.html#vboxmanage-modifyvm).
 
 ```yaml
 virtualbox: # All VirtualBox configuration has to be under the same `virtualbox` tag.
-   audio: dsound
+   audio: alsa
    audiocontroller: ac97
 ```
 


### PR DESCRIPTION
I suspect macOS provisioning was failing because of the wrong audio settings; since I don't have a Mac to test with I can't verify Mac provisioning is working, but this may help.