### PR TITLE
Eliminated duplicate Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,11 @@ script:
   # Run build script
   - .travis/build.sh
 
+branches:
+  only:
+    - master
+    - /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([\.\-].*)?$/
+
 env:
   global:
     # GIT_USERNAME


### PR DESCRIPTION
For each pull request two builds were being generated:

1. One for the push
2. One for the pull request

This was slowing down development because of the limited number of concurrent builds permitted.

This change ensures only the pull request build is created for pull requests; push builds will still run on the master branch and versioned branches/tags.