### PR TITLE
Fixed Jekyll build failure

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -6,8 +6,8 @@ RUN \
     libffi-dev ruby-dev yaml-dev zlib libxml2 build-base ruby-io-console readline \
     libxslt ruby yaml libffi nodejs ruby-irb ruby-json ruby-rake ruby-rdoc && \
 
-  # GitHub pages requires 1.6.8.1 rather than 1.6.8
-  yes | gem install nokogiri -v 1.6.8.1 && \
+  # GitHub pages requires 1.7.0 rather than 1.6.8
+  yes | gem install nokogiri -v 1.7.0 && \
 
   apk del zlib-dev build-base libxml2-dev libxslt-dev readline-dev libffi-dev \
     ruby-dev yaml-dev zlib-dev libxslt-dev readline-dev libxml2-dev \


### PR DESCRIPTION
github-pages requires nokogiri-1.7.0, which has to be compiled natively.