### PR TITLE
Added gulp-cli NPM module

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -141,6 +141,7 @@
       nodejs_npm_global_packages:
         - name: grunt-cli
         - name: grunt-init
+        - name: gulp-cli
 
     # Install Go language SDK
     - role: gantsign.golang


### PR DESCRIPTION
`gulp-cli` will now be pre-installed as a global module.