### PR TITLE
Disabled EditorConfig extension for vscode

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -242,7 +242,11 @@
       users:
         - username: vagrant
           visual_studio_code_extensions:
-            - EditorConfig.EditorConfig
+            # Temporarily disable EditorConfig extension as version 0.4.0 fails
+            # to install via the command line.
+            # Workaround: install manually via the GUI until the issue is
+            # resolved.
+            # - EditorConfig.EditorConfig
             - streetsidesoftware.code-spell-checker
             - wholroyd.jinja
             - donjayamanne.python


### PR DESCRIPTION
Temporarily disabled EditorConfig extension for Visual Studio code as version 0.4.0 fails to install via the command line.

Workaround: install manually via the GUI until the issue is resolved.