### PR TITLE
Restored vscode EditorConfig extension

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -242,11 +242,7 @@
       users:
         - username: vagrant
           visual_studio_code_extensions:
-            # Temporarily disable EditorConfig extension as version 0.4.0 fails
-            # to install via the command line.
-            # Workaround: install manually via the GUI until the issue is
-            # resolved.
-            # - EditorConfig.EditorConfig
+            - EditorConfig.EditorConfig
             - streetsidesoftware.code-spell-checker
             - wholroyd.jinja
             - donjayamanne.python


### PR DESCRIPTION
Installation is working again with version 0.6.0 of the extension.