### PR TITLE
Added support for JetBrains Go plugin

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -341,7 +341,7 @@
       users:
         - username: vagrant
           intellij_plugins:
-            - ro.redeul.google.go
+            - "{{ (intellij_edition == 'ultimate') | ternary('org.jetbrains.plugins.go', 'ro.redeul.google.go') }}"
 
     # Add Maven extension to popup a GUI notification when builds finish
     - role: gantsign.maven-notifier


### PR DESCRIPTION
If you're installing IntelliJ Ultimate Edition the JetBrains Go lang plugin will be installed instead of the third party Go lang plugin.

Since the JetBrains plugin is only available to Ultimate Edition users the third party plugin will still be installed when installing the Community Edition.