### PR TITLE
Excluded Visual Studio Code shared sockets from synchronization

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -57,6 +57,7 @@
         - Name bin
         - Name .bin
         - Name node_modules
+        - Name *-shared.sock
       unison_src_root: /home/vagrant
       unison_mirror_root: /var/persistent/home/vagrant
       unison_fat: no


### PR DESCRIPTION
Shared sockets created by Visual Studio Code  were causing the file synchronization to fail.