### PR TITLE
Fixed Rubocop warnings for Vagrant file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 Vagrant.require_version '>= 1.8.4'
 
 required_plugins = %w(vagrant-reload vagrant-persistent-storage vagrant-triggers vagrant-vbguest vagrant-proxyconf nugrant)
-plugins_to_install = required_plugins.select { |plugin| !Vagrant.has_plugin? plugin }
+plugins_to_install = required_plugins.reject { |plugin| Vagrant.has_plugin? plugin }
 unless plugins_to_install.empty?
   puts "Installing plugins: #{plugins_to_install.join(' ')}"
   if system "vagrant plugin install #{plugins_to_install.join(' ')}"
@@ -131,7 +131,7 @@ Vagrant.configure(2) do |config|
   }
 
   # Fail if Java is being installed and license hasn't been accepted.
-  config.trigger.before [:up, :provision] do
+  config.trigger.before %i(up provision) do
     if (!config.user.ansible.skip_tags.include? 'java') && config.user.java_license_declaration != 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
       abort "Aborting... to continue you must accept the Oracle Binary Code License Agreement\n(see https://github.com/gantsign/development-environment/wiki/Java-license-declaration)."
     end
@@ -266,16 +266,16 @@ Vagrant.configure(2) do |config|
 
   # Use persistent APT cache
   config.vm.provision 'shell', inline: <<SCRIPT
-persistent_mount='/var/persistent/var/cache/apt/archives /var/cache/apt/archives none bind 0 0'
-mkdir -p /var/persistent/var/cache/apt/archives \
-&& grep -q -F "${persistent_mount}" /etc/fstab || echo "${persistent_mount}" >> /etc/fstab \
-&& mount /var/cache/apt/archives
+  persistent_mount='/var/persistent/var/cache/apt/archives /var/cache/apt/archives none bind 0 0'
+  mkdir -p /var/persistent/var/cache/apt/archives \
+  && grep -q -F "${persistent_mount}" /etc/fstab || echo "${persistent_mount}" >> /etc/fstab \
+  && mount /var/cache/apt/archives
 
-persistent_mount='/var/persistent/usr/local/src/ansible/data /usr/local/src/ansible/data none bind 0 0'
-mkdir -p /var/persistent/usr/local/src/ansible/data \
-mkdir -p /usr/local/src/ansible/data \
-&& grep -q -F "${persistent_mount}" /etc/fstab || echo "${persistent_mount}" >> /etc/fstab \
-&& mount /usr/local/src/ansible/data
+  persistent_mount='/var/persistent/usr/local/src/ansible/data /usr/local/src/ansible/data none bind 0 0'
+  mkdir -p /var/persistent/usr/local/src/ansible/data \
+  mkdir -p /usr/local/src/ansible/data \
+  && grep -q -F "${persistent_mount}" /etc/fstab || echo "${persistent_mount}" >> /etc/fstab \
+  && mount /usr/local/src/ansible/data
 SCRIPT
 
   # Perform preliminary setup before the main Ansible provisioning


### PR DESCRIPTION
Version `0.48.0` of Rubocop has added new checks that were failing the build.