### PR TITLE
Excluded Visual Studio Code main socket from synchronization

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -58,6 +58,7 @@
         - Name .bin
         - Name node_modules
         - Name *-shared.sock
+        - Name *-main.sock
       unison_src_root: /home/vagrant
       unison_mirror_root: /var/persistent/home/vagrant
       unison_fat: no


### PR DESCRIPTION
Sockets created by Visual Studio Code  were causing the file synchronization to fail:

```
[ERROR] Skipping .config/Code/1.10.2-main.sock
  path /home/vagrant/.config/Code/1.10.2-main.sock has unknown file type
```