### PR TITLE
Updated Molecule to 1.24

### DIFF
--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -47,7 +47,7 @@
 - src: gantsign.maven-notifier
   version: '2.3.0'
 - src: gantsign.molecule
-  version: '2.2.0'
+  version: '3.0.0'
 - src: gantsign.postman
   version: '1.1.1'
 - src: gantsign.oh-my-zsh


### PR DESCRIPTION
Adds Ansible 2.3 support.