### PR TITLE
Fixed JAR packaged IntelliJ plugins install

### DIFF
--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -33,7 +33,7 @@
   version: '1.0.0'
 - src: gantsign.intellij
 - src: gantsign.intellij-plugins
-  version: '1.3.2'
+  version: '1.3.3'
 - src: gantsign.java
   version: '3.7.0'
 - src: gantsign.keyboard


### PR DESCRIPTION
JetBrains have added a query string to the plugin downloads, which had broken the detection for JAR packaged plugins (these plugins must not be extracted).

Also, stripped the query string from the file name of downloaded plugins.