### PR TITLE
Suppressed Rubocop false positive

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -2,7 +2,7 @@
 set -ev
 
 # Vagrantfile syntax check
-rubocop ./Vagrantfile --except LineLength,BlockLength,Eval,MutableConstant
+rubocop ./Vagrantfile --except LineLength,BlockLength,Eval,MutableConstant,FormatStringToken
 
 # Install Ansible roles
 sudo ansible-galaxy install -r provisioning/requirements.yml


### PR DESCRIPTION
This is a literal string not a string template (the variable replacement is done by Ansible not Ruby).

```
Vagrantfile:300:62: C: Prefer annotated tokens (like %<foo>s) over template tokens (like %{foo}).
    ansible.galaxy_command = 'alt-galaxy install --role-file=%{role_file} --roles-path=%{roles_path} --force'
                                                             ^^^^^^^^^^^^
Vagrantfile:300:88: C: Prefer annotated tokens (like %<foo>s) over template tokens (like %{foo}).
    ansible.galaxy_command = 'alt-galaxy install --role-file=%{role_file} --roles-path=%{roles_path} --force'
```