### PR TITLE
Removed IntelliJ Community Go plugin

### DIFF
--- a/docs/_docs/features.md
+++ b/docs/_docs/features.md
@@ -464,8 +464,7 @@ This development environment comes with Go language
 
 ### Go plugins for IDEs
 
-* [IntelliJ IDEA Community Edition (community plugin)](https://plugins.jetbrains.com/plugin/5047-go-language-golang-org-support-plugin)
-* [IntelliJ IDEA Ultimate Edition (JetBrains plugin)](https://plugins.jetbrains.com/plugin/9568-go)
+* [IntelliJ IDEA (Ultimate Edition only)](https://plugins.jetbrains.com/plugin/9568-go)
 * [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=lukehoban.Go)
 * [Atom](https://atom.io/packages/go-plus)
 

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -341,7 +341,8 @@
       users:
         - username: vagrant
           intellij_plugins:
-            - "{{ (intellij_edition == 'ultimate') | ternary('org.jetbrains.plugins.go', 'ro.redeul.google.go') }}"
+            - org.jetbrains.plugins.go
+      when: "intellij_edition == 'ultimate'"
 
     # Add Maven extension to popup a GUI notification when builds finish
     - role: gantsign.maven-notifier


### PR DESCRIPTION
Since the official Go plugin was release it's not being fully maintained.