### PR TITLE
Fixed Rubocop failure concerning correct API to get current directory

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ unless plugins_to_install.empty?
   end
 end
 
-vagrant_dir = File.expand_path(File.dirname(__FILE__))
+vagrant_dir = __dir__
 
 # All Vagrant configuration is done below. The '2' in Vagrant.configure
 # configures the configuration version (we support older styles for


### PR DESCRIPTION
```
Offenses:
Vagrantfile:18:15: C: Use __dir__ to get an absolute path to the current file's directory.
vagrant_dir = File.expand_path(File.dirname(__FILE__))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1 file inspected, 1 offense detected
```