### PR TITLE
Fixed Ubuntu Unity links in documentation

### DIFF
--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -209,8 +209,9 @@ keyboard:
 
 ### Desktop choice
 
-Each user can choose between the [Ubuntu Unity](https://unity.ubuntu.com)
-desktop or the [Xfce](http://www.xfce.org) desktop.
+Each user can choose between the
+[Ubuntu Unity](https://en.wikipedia.org/wiki/Unity_(Ubuntu)) desktop or the
+[Xfce](http://www.xfce.org) desktop.
 
 {% capture fig_img %}
 ![Desktop choice]({{ base_path }}/images/desktop-choice.png)

--- a/docs/_docs/features.md
+++ b/docs/_docs/features.md
@@ -210,8 +210,8 @@ ready to use.
 ### Choice of desktops
 
 This development environment offers the choice between
-[Ubuntu Unity](https://unity.ubuntu.com) and [Xfce](http://www.xfce.org)
-desktops.
+[Ubuntu Unity](https://en.wikipedia.org/wiki/Unity_(Ubuntu)) and
+[Xfce](http://www.xfce.org) desktops.
 
 Unity is the default desktop on Ubuntu and will be familiar to many Linux users.
 

--- a/docs/_posts/2016-09-06-unity.md
+++ b/docs/_posts/2016-09-06-unity.md
@@ -14,9 +14,9 @@ modified: 2016-09-06T22:25:24+01:00
 {% include base_path %}
 
 To make the development environment as robust as possible, the
-[Ubuntu Unity](https://unity.ubuntu.com) desktop is now installed by default. As
-Unity is the default desktop on Ubuntu it tends to have better support
-from third party apps.
+[Ubuntu Unity](https://en.wikipedia.org/wiki/Unity_(Ubuntu)) desktop is now
+installed by default. As Unity is the default desktop on Ubuntu it tends to have
+better support from third party apps.
 
 {% capture fig_img %}
 ![Desktop choice]({{ base_path }}/images/desktop-choice.png)


### PR DESCRIPTION
Ubuntu are ditching Unity for Gnome and appear to have shutdown the Ubuntu Unity site.

Changed links to point to the Wikipedia entry instead.