### PR TITLE
Fixed VS Code Python extension install

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -252,7 +252,7 @@
             - EditorConfig.EditorConfig
             - streetsidesoftware.code-spell-checker
             - wholroyd.jinja
-            - donjayamanne.python
+            - ms-python.python
             - rebornix.Ruby
           visual_studio_code_settings: {
             "editor.rulers": [80, 100, 120],


### PR DESCRIPTION
The Python extension is now an official Microsoft project.