### PR TITLE
Updated RoboCop config

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -2,7 +2,7 @@
 set -ev
 
 # Vagrantfile syntax check
-rubocop ./Vagrantfile --except LineLength,BlockLength,Eval,MutableConstant,FormatStringToken
+rubocop ./Vagrantfile --except LineLength,BlockLength,Eval,MutableConstant,FormatStringToken,EmptyLinesAroundArguments
 
 # Install Ansible roles
 sudo ansible-galaxy install -r provisioning/requirements.yml


### PR DESCRIPTION
Ignore new EmptyLinesAroundArguments inspection; this whitespace helps group related config.