### PR TITLE
Updated Kubernetes apt key

### DIFF
--- a/provisioning/init.yml
+++ b/provisioning/init.yml
@@ -15,7 +15,7 @@
     - name: add kubernetes key
       become: yes
       apt_key:
-        id: '3746C208A7317B0F'
+        id: '6A030B21BA07F4FB'
         url: 'https://packages.cloud.google.com/apt/doc/apt-key.gpg'
         state: present
 

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -39,7 +39,7 @@
 - src: gantsign.keyboard
   version: '1.2.1'
 - src: gantsign.kubernetes
-  version: '1.0.0'
+  version: '1.1.0'
 - src: gantsign.lightdm
   version: 'v2.0.1'
 - src: gantsign.maven


### PR DESCRIPTION
The previous key expired at the beginning of April.