### PR TITLE
Fixed locales role install

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -70,7 +70,7 @@
       keyboard_layout: gb
 
     # Configure locale
-    - role: tersmitten.locales
+    - role: oefenweb.locales
       locales_present:
         - en_GB.UTF-8
         - en_US.UTF-8

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -11,7 +11,7 @@
   version: '0.2.4'
 - src: geerlingguy.nodejs
   version: '4.2.0'
-- src: tersmitten.locales
+- src: oefenweb.locales
   version: 'v1.0.18'
 - src: gantsign.apt
   version: '1.2.0'


### PR DESCRIPTION
`tersmitten.locales` has moved to `oefenweb.locales`.