### PR TITLE
Fixed Oh My Zsh naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ environment that you can fork to add your project specific configuration.
 * Compressed RAM
 * File synchronization
 * Terminator
-* Oh-my-zsh
+* Oh My Zsh
 * Docker
 * Kubernetes
 * Visual Studio Code

--- a/docs/_docs/features.md
+++ b/docs/_docs/features.md
@@ -111,14 +111,14 @@ pwd
 
 This makes it really quick and easy to access your project directories.
 
-### Oh-my-zsh
+### Oh My Zsh
 
 Website: [http://ohmyz.sh](http://ohmyz.sh)
 
-Rather than a specific command, oh-my-zsh changes your default shell from `bash`
+Rather than a specific command, Oh My Zsh changes your default shell from `bash`
 to `zsh`, and customizes the `zsh` shell.
 
-Oh-my-zsh gives you:
+Oh My Zsh gives you:
 
 * Better tab completion (like expanding partial names in path).
 * Themes to enhance your command prompt (like showing the current git branch).


### PR DESCRIPTION
The naming convention is "Oh My Zsh" rather than "Oh-my-zsh".