### PR TITLE
Added zsh-syntax-highlighting plugin

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -458,6 +458,10 @@
             - name: sudo
             - name: zsh-autosuggestions
               url: zsh-users/zsh-autosuggestions
+            # bundles are loaded by name alpabetically
+            # and zsh-syntax-highlighting must be loaded last
+            - name: zzz
+              url: zsh-users/zsh-syntax-highlighting
 
     - role: gantsign.antigen_bundles
       tags:


### PR DESCRIPTION
To make it easier to use correct command syntax.