### PR TITLE
Changed backup/restore to use use rsync

### DIFF
--- a/.vagrantuser.example
+++ b/.vagrantuser.example
@@ -48,6 +48,7 @@
 # ansible:
 #   skip_tags:
 #     - atom
+#     - backup
 #     - chrome
 #     - docker
 #     - git-credential-manager
@@ -64,7 +65,6 @@
 #     - postman
 #     - python
 #     - sdkman
-#     - unison
 #     - vscode
 
 # Uncomment the section below to change any of the VirtualBox Settings

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ environment that you can fork to add your project specific configuration.
 ## Feature Highlights
 
 * Compressed RAM
-* File synchronization
+* File backup & restore between rebuilds
 * Terminator
 * Oh My Zsh
 * Docker

--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -290,6 +290,7 @@ ansible:
   skip_tags:
     # Choose from any of the below
     - atom
+    - backup
     - chrome
     - docker
     - git-credential-manager
@@ -306,7 +307,6 @@ ansible:
     - postman
     - python
     - sdkman
-    - unison
     - vscode
 ```
 

--- a/docs/_docs/features.md
+++ b/docs/_docs/features.md
@@ -5,7 +5,7 @@ description: >
   Features provided by the GantSign EnV development environment.
 numbered_headings: yes
 date: 2017-01-18T16:35:52+00:00
-modified: 2018-08-14T19:09:53+01:00
+modified: 2018-08-19T22:16:32+01:00
 ---
 
 {% include base_path %}
@@ -31,39 +31,44 @@ once.
 
 It's so fast there's no reason not to enable it by default.
 
-### File synchronization
+### File backup & restore between rebuilds
 
-Website: [https://www.cis.upenn.edu/~bcpierce/unison](https://www.cis.upenn.edu/~bcpierce/unison)
+Website: [https://rsync.samba.org](https://rsync.samba.org)
 
-One of the advantages of a using a virtual machine is it's easy to get back to a
+One of the advantages of using a virtual machine is it's easy to get back to a
 clean working state by rebuilding the virtual machine.
 
-However, you want to keep your user specific setup, and your workspace with all
+However, you want to keep your user-specific setup, and your workspace with all
 the repositories you've cloned.
 
-This project uses [unison](https://www.cis.upenn.edu/~bcpierce/unison) to
-synchronize selected files and folders from the client machine a separate
-persistent virtual disk on the host machine.
+This project uses [rsync](https://rsync.samba.org) to backup selected files and
+folders from the client virtual machine to a separate persistent virtual disk on
+the host machine.
 
 When the virtual machine is rebuilt, these files and folders are copied back to
 the new client virtual machine.
 
-The following are some of the files and folders synchronized by default:
+The following are some of the files and folders backed-up by default:
 
 * `/home/vagrant/workspace/`
 
-    * Put all your projects here.
-    * Tries to only synchronize source files by excluding directories like
-      `target`.
+    * **Put all your projects here**
 
 * `/home/vagrant/.gitconfig`
 * `/home/vagrant/.ssh/` (except the `authorized_keys` file)
 * `/home/vagrant/.gnupg/`
-* `/home/vagrant/.m2/`  (except the `repository` directory)
+* `/home/vagrant/.m2/`  (except the `repository` and `wrapper` directories)
 
-**Important:** ensure your important files have been synchronized to the
-persistent disk before rebuilding your virtual machine; you can find the
-persistent copies of your files under `/var/persistent/home/vagrant`.
+**Caution:** the followings directories are excluded from the backup by
+default: `.bin`, `.molecule`, `.tmp`, `bin`, `build`, `node_modules`, `target`.
+
+**Note:** you can find your backup under: `/var/persistent/home/vagrant/`.
+
+**Notice:** we accept no responsibility for files lost due to a failure of the
+backup/restore process. We recommend you push your work to your source control
+server before rebuilding your virtual machine. We also recommend you manually
+backup important keys and certificates (e.g. SSH, GPG, X.509) on your host
+machine.
 
 ## For command line users
 

--- a/provisioning/init.yml
+++ b/provisioning/init.yml
@@ -29,7 +29,6 @@
       with_items:
         - ppa:git-core/ppa
         - ppa:gnome-terminator/ppa
-        - ppa:john-freeman/unison
         - ppa:webupd8team/atom
         - 'deb http://apt.kubernetes.io/ kubernetes-xenial main'
       register: register_repos

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -23,46 +23,50 @@
     - role: gantsign.inotify
       inotify_max_user_watches: 524288
 
-    # Synchronize files/directories between client and host
-    - role: gantsign.unison
+    # Backup/restore files/directories in vagrant home directory
+    - role: gantsign.backup
       tags:
-        - unison
-      unison_include_directories:
-        - .ssh
-        - .gnupg
-        - .m2
-        - .atom
-        - .config/Code
-        - .config/Postman
-        - .local/share/keyrings
-        - workspace
-        - workspace-go
-      unison_include_files:
-        - .bash_history
-        - .zsh_history
-        - .gitconfig
-      unison_ignore_paths:
-        - Path .ssh/authorized_keys
-        - Path .gnupg/S.gpg-agent
-        - BelowPath .m2/repository
-        - BelowPath .m2/wrapper
-        - BelowPath .atom/.apm
-        - BelowPath .atom/.node-gyp
-        - BelowPath .atom/compile-cache
-        - BelowPath .atom/packages
-        - BelowPath .atom/storage
-        - Name target
-        - Name Cache
-        - Name GPUCache
-        - Name bin
-        - Name .bin
-        - Name node_modules
-        - Name *-shared.sock
-        - Name *-main.sock
-      unison_src_root: /home/vagrant
-      unison_mirror_root: /var/persistent/home/vagrant
-      unison_fat: no
-      unison_service_auto_start: yes
+        - backup
+      backup_user: vagrant
+      backup_src: /home/vagrant/
+      backup_dest: /var/persistent/home/vagrant/
+      backup_filter: |
+        !
+        + /.atom
+        + /.atom
+        + /.atom/config.cson
+        - /.atom/*
+        + /.bash_history
+        + /.config
+        + /.config/Code
+        + /.config/Code/User
+        + /.config/Code/User/settings.json
+        - /.config/Code/User/*
+        - /.config/Code/*
+        + /.config/Postman
+        - /.config/*
+        + /.gitconfig
+        + /.gnupg
+        + /.local/share/keyrings
+        + /.m2
+        - /.m2/repository
+        - /.m2/wrapper
+        + /.ssh
+        - /.ssh/authorized_keys
+        + /workspace
+        + /workspace-go
+        - /workspace-go/pkg
+        + /.zsh_history
+        - .bin
+        - .molecule
+        - .tmp
+        - bin
+        - build/*
+        - Cache
+        - GPUCache
+        - node_modules
+        - target/*
+        - /*
 
     # Set keyboard layout
     - role: gantsign.keyboard

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -25,6 +25,8 @@
   version: '1.1.0'
 - src: gantsign.audio
   version: '1.2.0'
+- src: gantsign.backup
+  version: '1.0.0'
 - src: https://github.com/gantsign/ansible-role-command-line-tools/archive/1.3.0.tar.gz
   name: gantsign.command-line-tools
 - src: gantsign.default-web-browser
@@ -66,8 +68,6 @@
   version: '1.0.0'
 - src: gantsign.terminator
   version: '1.1.0'
-- src: https://github.com/gantsign/ansible-role-unison/archive/1.3.0.tar.gz
-  name: gantsign.unison
 - src: gantsign.visual-studio-code
 - src: gantsign.visual-studio-code-extensions
   version: '1.4.0'


### PR DESCRIPTION
It made sense to use Unison for real-time synchronization when we were mirroring to a VirtualBox shared folder. However due to problems with the shared folders we moved to backing up to a second virtual disk instead.

Given we no longer need real-time synchronisation it makes sense to switch to rsync as it's more robust and better supported.