### PR TITLE
Changed to use native Vagrant triggers

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,10 +1,10 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# ansible_local requires version >= 1.8.4 to work stably
-Vagrant.require_version '>= 1.8.4'
+# We need Vagrant >= 2.1.0 becuse we use triggers
+Vagrant.require_version '>= 2.1.0'
 
-required_plugins = %w[vagrant-reload vagrant-persistent-storage vagrant-triggers vagrant-vbguest vagrant-proxyconf nugrant]
+required_plugins = %w[vagrant-reload vagrant-persistent-storage vagrant-vbguest vagrant-proxyconf nugrant]
 plugins_to_install = required_plugins.reject { |plugin| Vagrant.has_plugin? plugin }
 unless plugins_to_install.empty?
   puts "Installing plugins: #{plugins_to_install.join(' ')}"
@@ -138,7 +138,7 @@ Vagrant.configure(2) do |config|
   }
 
   # Fail if Java is being installed and license hasn't been accepted.
-  config.trigger.before %i[up provision] do
+  config.trigger.before [:up, :provision] do
     if (!config.user.ansible.skip_tags.include? 'java') && config.user.java_license_declaration != 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
       abort "Aborting... to continue you must accept the Oracle Binary Code License Agreement\n(see https://github.com/gantsign/development-environment/wiki/Java-license-declaration)."
     end


### PR DESCRIPTION
The triggers plugin was so popular they added it as a native feature in Vagrant 2.1.0. This change drops the `vagrant-triggers` plugin in favour of the native trigger support.