### PR TITLE
Fixed gantsign.zram_config role name

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -78,7 +78,7 @@
         lang: en_GB.UTF-8
 
     # Enable compressed RAM swap
-    - gantsign.zram-config
+    - gantsign.zram_config
 
     # Install common command line tools
     - gantsign.command-line-tools

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -63,5 +63,5 @@
   version: '1.4.0'
 - src: https://github.com/gantsign/ansible-role-xdesktop/archive/2.3.0.tar.gz
   name: gantsign.xdesktop
-- src: gantsign.zram-config
+- src: gantsign.zram_config
   version: '1.2.0'


### PR DESCRIPTION
Role name was changed from `gantsign.zram-config` to `gantsign.zram_config`.