### PR TITLE
Updated gantsign.pin-to-launcher role to 3.0.0

### DIFF
--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -61,7 +61,7 @@
 - src: gantsign.postman
   version: '2.1.0'
 - src: gantsign.pin-to-launcher
-  version: '2.1.0'
+  version: '3.0.0'
 - src: gantsign.sdkman
   version: '1.0.0'
 - src: gantsign.sdkman_init


### PR DESCRIPTION
For Ubuntu Bionic support.