### PR TITLE
Updated gantsign.git_credential_manager role to 1.2.0

### DIFF
--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -34,7 +34,7 @@
 - src: gantsign.default-web-browser
   version: '3.2.0'
 - src: gantsign.git_credential_manager
-  version: '1.0.0'
+  version: '1.2.0'
 - src: gantsign.git_user
   version: '1.0.0'
 - src: gantsign.gnome-proxy


### PR DESCRIPTION
Keeping up with the latest changes.