### PR TITLE
Dropped intellij_jdk_home var

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -325,7 +325,6 @@
         - gui
         - intellij
       intellij_edition: community
-      intellij_jdk_home: "{{ ansible_local.java.general.home }}"
       intellij_default_maven_home: "{{ ansible_local.maven.general.home }}"
       users:
         - username: vagrant


### PR DESCRIPTION
It's been replaced by `intellij_jdks`.