### PR TITLE
Documented IntelliJ inspection profile feature

### DIFF
--- a/docs/_docs/features.md
+++ b/docs/_docs/features.md
@@ -643,6 +643,12 @@ support for the following JVM languages:
 * Kotlin: based on the
   [Kotlin Style Guide](https://kotlinlang.org/docs/reference/coding-conventions.html)
 
+### IntelliJ inspection profile
+
+The [GantSign Inspection Profile](https://github.com/gantsign/inspection-profile-intellij)
+has support for Java and Kotlin. This is a strict inspection profile intended
+for greenfield code.
+
 ### SDKMAN!
 
 Website: [https://sdkman.io](https://sdkman.io)


### PR DESCRIPTION
So users understand why their IDE is lit-up like a Christmas tree :-)