### PR TITLE
Made Java 11 the default JDK

### DIFF
--- a/docs/_docs/features.md
+++ b/docs/_docs/features.md
@@ -660,13 +660,13 @@ Kotlin, Scala, Maven, Gradle and a bunch of other JVM based SDKs.
 To switch Java version in the current shell:
 
 ```bash
-sdk use java 10
+sdk use java 8
 ```
 
 To change the default Java version:
 
 ```bash
-sdk default java 10
+sdk default java 8
 ```
 
 To install Gradle:

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -194,14 +194,14 @@
       tags:
         - java
       java_version: 8u181
+      java_is_default_installation: no
+      java_fact_group_name: java_8
 
     # Install Java JDK 11
     - role: gantsign.java
       tags:
         - java
       java_version: 'jdk-11+28'
-      java_is_default_installation: no
-      java_fact_group_name: java_11
 
     # Install Maven
     - role: gantsign.maven
@@ -410,10 +410,10 @@
         - username: vagrant
           intellij_jdks:
             - name: '1.8'
-              home: "{{ ansible_local.java.general.home }}"
+              home: "{{ ansible_local.java_8.general.home }}"
             - name: '11'
-              home: "{{ ansible_local.java_11.general.home }}"
-          intellij_jdks_default: '1.8'
+              home: "{{ ansible_local.java.general.home }}"
+          intellij_jdks_default: '11'
 
     # Install Java related plugins for IntelliJ IDEA IDE
     - role: gantsign.intellij-plugins
@@ -639,12 +639,12 @@
           sdkman_install:
             - candidate: java
               version: '8'
-              path: '{{ ansible_local.java.general.home }}'
+              path: '{{ ansible_local.java_8.general.home }}'
             - candidate: java
               version: '11'
-              path: '{{ ansible_local.java_11.general.home }}'
+              path: '{{ ansible_local.java.general.home }}'
           sdkman_default:
-            java: '8'
+            java: '11'
 
     - role: gantsign.sdkman_init
       tags:

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -47,7 +47,7 @@
   version: '1.2.0'
 - src: gantsign.intellij
 - src: gantsign.intellij_jdks
-  version: '1.0.0'
+  version: '1.0.1'
 - src: gantsign.intellij-plugins
   version: '2.0.1'
 - src: gantsign.java


### PR DESCRIPTION
Oracle is ending public support for for Java 8 in January 2019 so it's time to give developers a nudge.