### PR TITLE
Fixed GNOME name

### DIFF
--- a/.vagrantuser.example
+++ b/.vagrantuser.example
@@ -31,7 +31,7 @@
 #   http: 'http://example.com:3128/'
 
 # Uncomment (and configure) the section below to use proxy auto configuration
-# for the Gnome desktop.
+# for the GNOME desktop.
 # gnome_proxy:
 #   mode: auto
 #   autoconfig_url: 'http://example.com/proxy.pac'

--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -84,13 +84,13 @@ git_proxy:
   http: 'http://proxy.example.com:3128/'
 ```
 
-#### Gnome proxy override
+#### GNOME proxy override
 
-If you need to use a different proxy for Gnome applications, or just want to
-take advantage of more advanced proxy options for Gnome applications, you can
+If you need to use a different proxy for GNOME applications, or just want to
+take advantage of more advanced proxy options for GNOME applications, you can
 follow the documentation below.
 
-Note: the Gnome proxy settings are also used by some other non-gnome
+Note: the GNOME proxy settings are also used by some other non-GNOME
 applications such as the Google Chrome web browser.
 
 ##### Proxy auto-config
@@ -105,7 +105,7 @@ gnome_proxy:
   autoconfig_url: 'http://wpad.example.com/wpad.dat'
 ```
 
-Note: in theory Gnome should be able to auto-discover the value for the
+Note: in theory GNOME should be able to auto-discover the value for the
 `autoconfig_url` using the
 [Web Proxy Auto-Discovery Protocol](https://en.wikipedia.org/wiki/Web_Proxy_Autodiscovery_Protocol);
 in practice auto-discovery is unlikely to work when you're running Linux in a
@@ -114,7 +114,7 @@ have to specify the location manually.
 
 ##### Minimal manual configuration
 
-To manually specify a different proxy for Gnome applications add the following
+To manually specify a different proxy for GNOME applications add the following
 to the `.vagrantuser` file (replace the hosts and ports with the values for your
 network):
 

--- a/docs/_posts/2016-10-03-proxy.md
+++ b/docs/_posts/2016-10-03-proxy.md
@@ -22,7 +22,7 @@ still required to get Google Chrome to use the proxy.
 This has now been addressed by updates to both the
 [Getting Started]({{ base_path }}/docs/getting-started) documentation and the
 [Configuration]({{ base_path }}/docs/configuration) documentation; the
-`vagrant-proxyconf` plugin is now auto-installed and the Gnome proxy is
+`vagrant-proxyconf` plugin is now auto-installed and the GNOME proxy is
 configured as part of the provisioning; the proxy configuration is part of the
 standard Nugrant configuration approach, so you can set the default values in
 the `Vagrantfile` and users can override it in their `.vagrantuser` files if

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -244,7 +244,7 @@
       audio_users:
         - vagrant
 
-    # Install Gnome desktop
+    # Install GNOME desktop
     - role: gantsign.xdesktop
       xdesktop_desktop: gnome
       tags:
@@ -255,7 +255,7 @@
       tags:
         - gui
 
-    # Configure proxy settings for Gnome applications
+    # Configure proxy settings for GNOME applications
     - role: gantsign.gnome-proxy
       tags:
         - proxy


### PR DESCRIPTION
The name should be in uppercase.