### PR TITLE
Fixed Git Credential Manager JVM install

### DIFF
--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -32,7 +32,7 @@
 - src: gantsign.fd
   version: '1.0.0'
 - src: gantsign.git_credential_manager
-  version: '1.2.1'
+  version: '1.3.0'
 - src: gantsign.git_user
   version: '1.1.0'
 - src: gantsign.gnome-proxy


### PR DESCRIPTION
AdoptOpenJDK now has a choice of OpenJ9 releases for heap size.