### PR TITLE
Fixed rubocop warning FrozenStringLiteralComment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 


### PR DESCRIPTION
`Vagrantfile:1:1: C: Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.`