### PR TITLE
Excluded pull request URLs from htmlproofer

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -20,7 +20,7 @@ run() {
     done
     htmlproofer /tmp/_site --log-level debug \
         --url-swap "^/development-environment:" \
-        --url-ignore 'http://www.xfce.org'
+        --url-ignore 'http://www.xfce.org,//github.com/gantsign/development-environment/pull/'
 }
 
 docker_build() {


### PR DESCRIPTION
It seems we're exceeding the URL request limits for GitHub.