### PR TITLE
Fixed compatibility with vagrant-proxyconf

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -699,3 +699,26 @@
               path: '{{ ansible_local.maven.general.home }}'
           sdkman_default:
             maven: '3.6'
+
+  post_tasks:
+    # Fix for: https://github.com/gantsign/development-environment/issues/598
+    - name: fix for vagrant-proxyconf compatibility (docker.service.d)
+      become: yes
+      file:
+        path: /etc/systemd/system/docker.service.d
+        state: directory
+        owner: root
+        group: root
+        mode: 'u=rwx,go=rx'
+      tags:
+        - docker
+    - name: fix for vagrant-proxyconf compatibility (http-proxy.conf)
+      become: yes
+      copy:
+        content: ''
+        dest: /etc/systemd/system/docker.service.d/http-proxy.conf
+        owner: root
+        group: root
+        mode: 'u=rw,go=r'
+      tags:
+        - docker


### PR DESCRIPTION
Required for `vagrant-proxyconf >= 2.0.2`.

Fix: resolves #598