### PR TITLE
Updated Travis CI test to use Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ language: python
 
 python:
   # Specify Python version
-  - '2.7'
+  - '3.6'
 
 install:
   # Install lint tools.


### PR DESCRIPTION
Python 2.7 is almost out of support.