### PR TITLE
Updated gantsign.intellij_jdks role to 2.0.0

### DIFF
--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -41,7 +41,7 @@
   version: '1.2.1'
 - src: gantsign.intellij
 - src: gantsign.intellij_jdks
-  version: '1.0.1'
+  version: '2.0.0'
 - src: gantsign.intellij-plugins
   version: '2.0.2'
 - src: gantsign.java


### PR DESCRIPTION
For compatibility with IntelliJ 2020.1.