### PR TITLE
Dropped alt-galaxy

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -299,10 +299,6 @@ SCRIPT
     ansible.playbook = 'provisioning/playbook.yml'
     ansible.galaxy_role_file = 'provisioning/requirements.yml'
 
-    # Use alt-galaxy to download roles instead of ansible-galaxy.
-    # Workaround for: "[ERROR]: failed to download the file: [Errno 104] Connection reset by peer"
-    ansible.galaxy_command = 'alt-galaxy install --role-file=%{role_file} --roles-path=%{roles_path} --force'
-
     ansible.extra_vars = {
       timezone: config.user.timezone,
 

--- a/provisioning/init.yml
+++ b/provisioning/init.yml
@@ -3,14 +3,6 @@
 
   pre_tasks:
 
-    # Install alt-galaxy
-    - name: install alt-galaxy
-      become: yes
-      unarchive:
-        src: https://github.com/gantsign/alt-galaxy/releases/download/1.4.1/alt-galaxy_linux_amd64.tar.xz
-        remote_src: yes
-        dest: /usr/local/bin
-
     # Reduce the number of times `apt-get update` needs to be run by
     # pre-registering repositories
 


### PR DESCRIPTION
`alt-galaxy` appears to be so fast it's hitting GitHub's rate limits. It also appears ansible-galaxy's reliability has improved.