### PR TITLE
Removed fd Zsh alias fix

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -563,9 +563,6 @@
             - name: bat
               url: gantsign/zsh-plugins
               location: bat
-            - name: fd
-              url: gantsign/zsh-plugins
-              location: fd
             - name: moleculew
               url: gantsign/molecule-wrapper
               location: zsh


### PR DESCRIPTION
It's no longer required.