### PR TITLE
Fixed dependabot builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           ANSIBLE_ROLES_PATH: '$HOME/roles'
 
       - name: Login to Docker Hub
-        if: '!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository'
+        if: "!github.event.pull_request || (github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.ref, 'refs/heads/dependabot/'))"
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Avoid Docker login as secrets are missing.