### PR TITLE
Updated gantsign.intellij-plugins role to 3.1.1

### DIFF
--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -43,7 +43,7 @@
 - src: gantsign.intellij_jdks
   version: '2.0.0'
 - src: gantsign.intellij-plugins
-  version: '3.1.0'
+  version: '3.1.1'
 - src: gantsign.java
   version: '9.2.1'
 - src: gantsign.keyboard


### PR DESCRIPTION
For Ubuntu 20.04 support.