### PR TITLE
Specified new galaxy_roles_path location

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -299,6 +299,7 @@ SCRIPT
   config.vm.provision 'ansible_local' do |ansible|
     ansible.playbook = 'provisioning/playbook.yml'
     ansible.galaxy_role_file = 'provisioning/requirements.yml'
+    ansible.galaxy_roles_path = '/home/vagrant/.ansible/roles'
 
     ansible.extra_vars = {
       ansible_python_interpreter: '/usr/bin/python3',


### PR DESCRIPTION
Newer versions of ansible-galaxy have issues downloading to the VirtualBox shared folder.