### PR TITLE
Migrated to the new .NET based Git Credential Manager

### DIFF
--- a/docs/_docs/features.md
+++ b/docs/_docs/features.md
@@ -5,7 +5,7 @@ description: >
   Features provided by the GantSign EnV development environment.
 numbered_headings: yes
 date: 2017-01-18T16:35:52+00:00
-modified: 2022-01-03T19:17:25+00:00
+modified: 2022-01-03T19:35:36+00:00
 ---
 
 There are a lot of well known projects, and hidden gems, which aid in your
@@ -502,19 +502,12 @@ A GUI diff/merge tool with Git support.
 Tip: run `meld .` in your Git working directory to review your uncommitted
 changes.
 
-### Git Credential Manager for Mac and Linux
+### Git Credential Manager
 
-Website: [https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux](https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux)
+Website: [https://github.com/GitCredentialManager/git-credential-manager](https://github.com/GitCredentialManager/git-credential-manager)
 
 Stores credentials for Git version control securely. Useful if you want to write
 to a Git repository using HTTPS rather than SSH.
-
-Note: if you use two-factor authentication with GitHub (you'd be crazy not to),
-you need to generate a
-[personal access token](https://github.com/settings/tokens) with appropriate
-repository permissions. When using Git in the VM, enter this personal access
-token when prompted to enter your password (instead of entering your GitHub
-password).
 
 ### Hub
 

--- a/docs/_posts/2018-10-15-2.0.0-release.md
+++ b/docs/_posts/2018-10-15-2.0.0-release.md
@@ -10,7 +10,7 @@ excerpt: >
   Major release with many changes, read for details...
 read_time: no
 date: 2018-10-15T19:18:26+01:00
-modified: 2018-10-16T10:38:52+01:00
+modified: 2022-01-03T19:53:24+00:00
 ---
 
 ## Release highlights
@@ -125,7 +125,7 @@ Ubuntu Bionic Beaver
 * Added [hub]({{ '/docs/features/#hub' | relative_url }}) wrapper for Git with
   additional features for GitHub
 * Added
-  [Git Credential Manager for Mac and Linux]({{ '/docs/features/#git-credential-manager-for-mac-and-linux' | relative_url }})
+  [Git Credential Manager for Mac and Linux]({{ '/docs/features/#git-credential-manager' | relative_url }})
 * Added new Git aliases
 
     * Checkout an existing branch


### PR DESCRIPTION
This supersedes the old Java based Git Credential Manager for Mac and Linux.