### PR TITLE
Changed the way Terminator is installed

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -298,11 +298,6 @@
         - git-credential-manager
         - gui
 
-    # Install Terminator terminal emulator
-    - role: gantsign.terminator
-      tags:
-        - gui
-
     # Install Google Chrome web browser
     - role: cmprescott.chrome
       tags:

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -76,15 +76,13 @@
   version: '1.2.2'
 - src: gantsign.swapspace
   version: '1.0.1'
-- src: gantsign.terminator
-  version: '2.0.2'
 - src: gantsign.timezone
   version: '1.1.1'
 - src: gantsign.visual-studio-code
   version: '6.7.0'
 - src: gantsign.visual-studio-code-extensions
   version: '2.4.0'
-- src: https://github.com/gantsign/ansible-role-xdesktop/archive/5.2.0.tar.gz
+- src: https://github.com/gantsign/ansible-role-xdesktop/archive/5.3.0.tar.gz
   name: gantsign.xdesktop
 - src: gantsign.zswap
   version: '1.0.1'


### PR DESCRIPTION
Since the APT package is reasonably up to date, there's no need for a separate role.