### PR TITLE
Changed the way Pipenv is installed

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -218,13 +218,6 @@
       pyenv_users:
         - vagrant
 
-    # Install Pipenv
-    - role: gantsign.pipenv
-      tags:
-        - python
-      pipenv_users:
-        - vagrant
-
     # Install Java JDK 8
     - role: gantsign.java
       tags:
@@ -653,8 +646,6 @@
             - name: pip
             - name: pyenv
             - name: pipenv
-              url: gantsign/zsh-plugins
-              location: pipenv
 
     - role: gantsign.antigen_bundles
       tags:
@@ -705,6 +696,13 @@
             maven: '3.6'
 
   post_tasks:
+    # Install Pipenv
+    - name: install Pipenv
+      package:
+        name: pipenv
+      tags:
+        - python
+
     # Install Postman HTTP tool
     - name: install Postman
       snap:

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -60,8 +60,6 @@
 - src: gantsign.maven-notifier
   version: '3.0.2'
 - src: gantsign.minikube
-- src: gantsign.pipenv
-  version: '2.0.0'
 - src: gantsign.pin-to-launcher
   version: '4.0.0'
 - src: gantsign.pwquality


### PR DESCRIPTION
Recent versions of Pipenv give a deprecation warning about the Ubuntu Python version. Switching to the Pipenv APT package resolves this issue.