### PR TITLE
Fixed some apt-key deprecation warnings

### DIFF
--- a/provisioning/init.yml
+++ b/provisioning/init.yml
@@ -6,11 +6,20 @@
     # Reduce the number of times `apt-get update` needs to be run by
     # pre-registering repositories
 
+    - name: Create APT keyrings dir
+      become: yes
+      file:
+        path: '/etc/apt/keyrings'
+        state: directory
+        mode: 'u=rwx,go=rx'
+
     - name: add kubernetes key
       become: yes
-      apt_key:
+      get_url:
         url: 'https://packages.cloud.google.com/apt/doc/apt-key.gpg'
-        state: present
+        dest: '/etc/apt/keyrings/cloud.google.gpg'
+        mode: 'u=rw,go=r'
+        force: yes
       tags:
         - docker
         - kubernetes
@@ -18,7 +27,9 @@
     - name: add kubernetes repo
       become: yes
       apt_repository:
-        repo: 'deb http://apt.kubernetes.io/ kubernetes-xenial main'
+        repo: >-
+          deb [signed-by=/etc/apt/keyrings/cloud.google.gpg]
+          http://apt.kubernetes.io/ kubernetes-xenial main
         update_cache: no
       tags:
         - docker
@@ -27,9 +38,11 @@
 
     - name: add Google Linux key
       become: yes
-      apt_key:
+      get_url:
         url: 'https://dl-ssl.google.com/linux/linux_signing_key.pub'
-        state: present
+        dest: '/etc/apt/keyrings/linux.google.asc'
+        mode: 'u=rw,go=r'
+        force: yes
       tags:
         - gui
         - chrome
@@ -37,7 +50,9 @@
     - name: add Google Chrome repo
       become: yes
       apt_repository:
-        repo: 'deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main'
+        repo: >-
+          deb [arch=amd64 signed-by=/etc/apt/keyrings/linux.google.asc]
+          https://dl.google.com/linux/chrome/deb/ stable main
         filename: google-chrome
         update_cache: no
       tags:
@@ -47,9 +62,11 @@
 
     - name: add vscode key
       become: yes
-      apt_key:
+      get_url:
         url: 'https://packages.microsoft.com/keys/microsoft.asc'
-        state: present
+        dest: '/etc/apt/keyrings/'
+        mode: 'u=rw,go=r'
+        force: yes
       tags:
         - gui
         - vscode
@@ -57,7 +74,9 @@
     - name: add vscode repo
       become: yes
       apt_repository:
-        repo: 'deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main'
+        repo: >-
+          deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.asc]
+          https://packages.microsoft.com/repos/code stable main
         filename: vscode
         update_cache: no
       tags:

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -48,7 +48,7 @@
   version: '1.5.0'
 - src: gantsign.kompose
 - src: gantsign.kubernetes
-  version: '3.1.0'
+  version: '3.2.0'
 - src: gantsign.lightdm
   version: 'v3.0.1'
 - src: gantsign.maven


### PR DESCRIPTION
Ubuntu 22.04 will be the last release with apt-key (see https://manpages.ubuntu.com/manpages/jammy/man8/apt-key.8.html).