### PR TITLE
Dropped Java 8 JDK

### DIFF
--- a/docs/_docs/features.md
+++ b/docs/_docs/features.md
@@ -5,7 +5,7 @@ description: >
   Features provided by the GantSign EnV development environment.
 numbered_headings: yes
 date: 2017-01-18T16:35:52+00:00
-modified: 2023-09-01T09:24:24+01:00
+modified: 2023-09-01T09:54:32+01:00
 ---
 
 There are a lot of well known projects, and hidden gems, which aid in your
@@ -738,13 +738,13 @@ Kotlin, Scala, Maven, Gradle and a bunch of other JVM based SDKs.
 To switch Java version in the current shell:
 
 ```bash
-sdk use java 8
+sdk use java 11
 ```
 
 To change the default Java version:
 
 ```bash
-sdk default java 8
+sdk default java 11
 ```
 
 To install Gradle:
@@ -760,10 +760,10 @@ To play with GraalVM:
 sdk list java
 
 # Install latest GraalVM version
-sdk install java 1.0.0-rc5-graal
+sdk install java 17.0.8-graalce
 
 # Switch to GraalVM in the current shell
-sdk use java 1.0.0-rc5-graal
+sdk use java 17.0.8-graalce
 ```
 
 To list all the supported SDKs:

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -235,13 +235,13 @@
       tags:
         - python
 
-    # Install Java JDK 8
+    # Install Java JDK 11
     - role: gantsign.java
       tags:
         - java
-      java_version: '8.0.382+5'
+      java_version: '11.0.20.1+1'
       java_is_default_installation: no
-      java_fact_group_name: java_8
+      java_fact_group_name: java_11
 
     # Install Java JDK 17
     - role: gantsign.java
@@ -435,8 +435,8 @@
       users:
         - username: '{{ my_user }}'
           intellij_jdks:
-            - name: '1.8'
-              home: "{{ ansible_local.java_8.general.home }}"
+            - name: '11'
+              home: "{{ ansible_local.java_11.general.home }}"
             - name: '17'
               home: "{{ ansible_local.java.general.home }}"
           intellij_jdks_default: '17'
@@ -537,8 +537,8 @@
         - username: '{{ my_user }}'
           sdkman_install:
             - candidate: java
-              version: '8'
-              path: '{{ ansible_local.java_8.general.home }}'
+              version: '11'
+              path: '{{ ansible_local.java_11.general.home }}'
             - candidate: java
               version: '17'
               path: '{{ ansible_local.java.general.home }}'


### PR DESCRIPTION
Java 11 is now the minimum JDK installed.