### PR TITLE
Simplified setting initial password

### DIFF
--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -5,7 +5,7 @@ description: >
   How to setup the development environment.
 numbered_headings: yes
 date: 2016-08-31T09:05:34+01:00
-modified: 2023-09-01T07:29:53+01:00
+modified: 2023-09-17T08:06:24+01:00
 ---
 
 The following instructions will guide you through the process of provisioning
@@ -162,9 +162,8 @@ vagrant vbguest --do install
 
 ## Change your password
 
-Once provisioning is complete you need to change your password. Login using the
-username `dev` and password `dev`. You'll then be prompted to change
-your password.
+Once provisioning is complete you need to set your password. Login using the
+username `dev`. You'll then be prompted to set your password.
 
 Pick a strong password and don't reuse another password (e.g. don't use your
 Windows password). This password will be used to secure access to saved
@@ -173,9 +172,6 @@ passwords in your browser, SSH key passwords and Git credentials etc.
 The password needs to be at least 16 characters long and you cannot repeat the
 same character more than 3 times in a row. Prefer long easy to remember phrases
 over difficult to remember random passwords.
-
-**Important:** you need to complete this procedure before you stop/reload the
-VM.
 
 ## Stopping the virtual machine
 

--- a/docs/_docs/upgrade.md
+++ b/docs/_docs/upgrade.md
@@ -5,7 +5,7 @@ description: >
   How to upgrade your development environment to the latest release.
 numbered_headings: yes
 date: 2018-10-12T13:07:23+01:00
-modified: 2023-09-01T07:35:24+01:00
+modified: 2023-09-17T08:09:35+01:00
 ---
 
 The following instructions will guide you through the process of upgrading your
@@ -140,8 +140,8 @@ vagrant vbguest --do install
 #### Unable to save credentials
 
 Your Unix password may get out of sync with the password for your GNOME Keyring
-when you rebuild your development-environment (as the Unix password is reset to
-`dev`) or if you reset the password without specifying the current password
+when you rebuild your development-environment
+or if you reset the password without specifying the current password
 (e.g. using `sudo passwd dev`).
 
 Once your GNOME Keyring password is out of sync the keyring won't unlock when
@@ -194,12 +194,10 @@ After this is complete logout and log back in so your key is loaded.
 
 ## Change your password
 
-Once provisioning is complete you need to change your password. Login using the
-username `dev` and password `dev`. You'll then be prompted to change
-your password. **Important:** change the password to the password you were
+Once provisioning is complete you need to set your password. Login using the
+username `dev`. You'll then be prompted to set
+your password. **Important:** set the password to the password you were
 using before you re-provisioned the development environment. This is necessary
-to restore access to all your saved credentials. Once you've changed your
+to restore access to all your saved credentials. Once you've set your
 password you need to logout and log back in (with the new password) for your
 keyring to be unlocked.
-
-**Important:** you need to change the password before you stop/reload the VM.

--- a/provisioning/roles/create_user/tasks/main.yml
+++ b/provisioning/roles/create_user/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: Create user
   ansible.builtin.user:
     name: '{{ my_user }}'
-    # Initial password is "dev" (must be changed on first login)
-    password: '$6$ab38evLL$WgKntDGuJnk9Ev3xqA3rFm/PFtV2iTLRgbGZqrvFrIyJm6ELqoupPTULJEg3TKc4OD3z1KS90kC94xNVBbIF61'
+    password: '!' # This sets the password to 'locked'
+    update_password: on_create
     groups:
       - adm
       - cdrom
@@ -11,14 +11,31 @@
       - dip
       - plugdev
       - lxd
+    append: true
   register: create_user_result
+
+- name: Don't require password on first login
+  ansible.builtin.command: 'passwd -d {{ my_user }}'
+  args:
+    creates: ~{{ my_user }}/.setpwd
+  when: create_user_result.changed
 
 - name: Change password on first login
   ansible.builtin.command: 'chage --lastday 0 {{ my_user }}'
+  args:
+    creates: ~{{ my_user }}/.setpwd
   when: create_user_result.changed
 
+- name: Remember change password on first login
+  become: true
+  become_user: '{{ my_user }}'
+  ansible.builtin.copy:
+    content: ''
+    dest: ~/.setpwd
+    force: false
+
 - name: Create remote_tmp directory
-  file:
+  ansible.builtin.file:
     path: '/home/{{ my_user }}/.ansible/tmp'
     state: directory
     mode: 'u=rwx,go='


### PR DESCRIPTION
You can now go straight into setting the password without specifying the previous password. Also, rerunning provisioning now won't require a password reset.