### PR TITLE
Added color to command line help output

### DIFF
--- a/provisioning/roles/more_cli_tools/tasks/main.yml
+++ b/provisioning/roles/more_cli_tools/tasks/main.yml
@@ -4,6 +4,7 @@
   become_user: '{{ my_user }}'
   community.general.homebrew:
     name:
+      - bat # to get newer version with --language help
       - bandwhich
       - dust
       - gh

--- a/provisioning/roles/zsh/files/custom.zsh
+++ b/provisioning/roles/zsh/files/custom.zsh
@@ -53,6 +53,11 @@ if (( $+commands[bat] )) || (( $+commands[batcat] )); then
     # compdef shfmt_with_bat=shfmt
     alias shfmt=shfmt_with_bat
   fi
+
+  if (( $+commands[bat] )); then
+    # batcat doesn't support --language=help (old version)
+    alias -g -- --help='--help 2>&1 | bat --language=help --style=plain'
+  fi
 fi
 
 if (( $+commands[lsd] )); then


### PR DESCRIPTION
Add color to command line help output using `bat`.